### PR TITLE
Make it compile fibonacci

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,10 +8,11 @@ import           Language.PureScript.CoreFn.Module             (Module)
 import           Language.PureScript.CoreFn.Ann                (Ann)
 import           Language.PureScript.Scheme.CodeGen.Transpiler (moduleToScheme)
 import           Language.PureScript.Scheme.CodeGen.Printer    (printScheme)
+import           Language.PureScript.Scheme.CodeGen.Optimizer  (runOptimizations)
 
 main :: IO ()
-main = (printScheme . moduleToScheme)
-   <$> readJSONFile "resources/PureScmTest.Literals.corefn.json"
+main = (printScheme . runOptimizations . moduleToScheme)
+   <$> readJSONFile "resources/PureScmTest.Inc.corefn.json"
    >>= T.putStrLn
 
 readJSONFile :: FilePath -> IO (Module Ann)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import           Data.Text                                     (Text)
 import           Data.Text.IO                                  as T (putStrLn)
 import qualified Data.Aeson                                    as JSON
 import qualified Data.Aeson.Types                              as JSON.T
@@ -11,9 +12,11 @@ import           Language.PureScript.Scheme.CodeGen.Printer    (printScheme)
 import           Language.PureScript.Scheme.CodeGen.Optimizer  (runOptimizations)
 
 main :: IO ()
-main = (printScheme . runOptimizations . moduleToScheme)
-   <$> readJSONFile "resources/PureScmTest.Inc.corefn.json"
-   >>= T.putStrLn
+main = compile "resources/PureScmTest.Fib.corefn.json" >>= T.putStrLn
+
+compile :: FilePath -> IO Text
+compile path = (printScheme . runOptimizations . moduleToScheme)
+           <$> readJSONFile path
 
 readJSONFile :: FilePath -> IO (Module Ann)
 readJSONFile path = do

--- a/resources/PureScmTest.Fib.corefn.json
+++ b/resources/PureScmTest.Fib.corefn.json
@@ -1,0 +1,758 @@
+{
+  "moduleName": [
+    "PureScmTest",
+    "Fib"
+  ],
+  "reExports": {
+  },
+  "imports": [
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "start": [
+            1,
+            1
+          ],
+          "end": [
+            7,
+            30
+          ]
+        }
+      },
+      "moduleName": [
+        "Data",
+        "Ring"
+      ]
+    },
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "start": [
+            1,
+            1
+          ],
+          "end": [
+            7,
+            30
+          ]
+        }
+      },
+      "moduleName": [
+        "Data",
+        "Semiring"
+      ]
+    },
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "start": [
+            3,
+            1
+          ],
+          "end": [
+            3,
+            15
+          ]
+        }
+      },
+      "moduleName": [
+        "Prelude"
+      ]
+    },
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "start": [
+            1,
+            1
+          ],
+          "end": [
+            7,
+            30
+          ]
+        }
+      },
+      "moduleName": [
+        "Prim"
+      ]
+    },
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "start": [
+            1,
+            1
+          ],
+          "end": [
+            7,
+            30
+          ]
+        }
+      },
+      "moduleName": [
+        "PureScmTest",
+        "Fib"
+      ]
+    }
+  ],
+  "builtWith": "0.14.1",
+  "modulePath": "src/PureScmTest/Fib.purs",
+  "exports": [
+    "fib"
+  ],
+  "decls": [
+    {
+      "binds": [
+        {
+          "annotation": {
+            "meta": null,
+            "sourceSpan": {
+              "start": [
+                5,
+                1
+              ],
+              "end": [
+                5,
+                10
+              ]
+            }
+          },
+          "identifier": "fib",
+          "expression": {
+            "annotation": {
+              "meta": null,
+              "sourceSpan": {
+                "start": [
+                  5,
+                  1
+                ],
+                "end": [
+                  5,
+                  10
+                ]
+              }
+            },
+            "body": {
+              "annotation": {
+                "meta": null,
+                "sourceSpan": {
+                  "start": [
+                    5,
+                    1
+                  ],
+                  "end": [
+                    5,
+                    10
+                  ]
+                }
+              },
+              "caseExpressions": [
+                {
+                  "annotation": {
+                    "meta": null,
+                    "sourceSpan": {
+                      "start": [
+                        5,
+                        1
+                      ],
+                      "end": [
+                        5,
+                        10
+                      ]
+                    }
+                  },
+                  "value": {
+                    "moduleName": null,
+                    "identifier": "v"
+                  },
+                  "type": "Var"
+                }
+              ],
+              "caseAlternatives": [
+                {
+                  "binders": [
+                    {
+                      "annotation": {
+                        "meta": null,
+                        "sourceSpan": {
+                          "start": [
+                            5,
+                            5
+                          ],
+                          "end": [
+                            5,
+                            6
+                          ]
+                        }
+                      },
+                      "literal": {
+                        "literalType": "IntLiteral",
+                        "value": 0
+                      },
+                      "binderType": "LiteralBinder"
+                    }
+                  ],
+                  "expression": {
+                    "annotation": {
+                      "meta": null,
+                      "sourceSpan": {
+                        "start": [
+                          5,
+                          9
+                        ],
+                        "end": [
+                          5,
+                          10
+                        ]
+                      }
+                    },
+                    "value": {
+                      "literalType": "IntLiteral",
+                      "value": 0
+                    },
+                    "type": "Literal"
+                  },
+                  "isGuarded": false
+                },
+                {
+                  "binders": [
+                    {
+                      "annotation": {
+                        "meta": null,
+                        "sourceSpan": {
+                          "start": [
+                            6,
+                            5
+                          ],
+                          "end": [
+                            6,
+                            6
+                          ]
+                        }
+                      },
+                      "literal": {
+                        "literalType": "IntLiteral",
+                        "value": 1
+                      },
+                      "binderType": "LiteralBinder"
+                    }
+                  ],
+                  "expression": {
+                    "annotation": {
+                      "meta": null,
+                      "sourceSpan": {
+                        "start": [
+                          6,
+                          9
+                        ],
+                        "end": [
+                          6,
+                          10
+                        ]
+                      }
+                    },
+                    "value": {
+                      "literalType": "IntLiteral",
+                      "value": 1
+                    },
+                    "type": "Literal"
+                  },
+                  "isGuarded": false
+                },
+                {
+                  "binders": [
+                    {
+                      "annotation": {
+                        "meta": null,
+                        "sourceSpan": {
+                          "start": [
+                            7,
+                            5
+                          ],
+                          "end": [
+                            7,
+                            6
+                          ]
+                        }
+                      },
+                      "identifier": "n",
+                      "binderType": "VarBinder"
+                    }
+                  ],
+                  "expression": {
+                    "annotation": {
+                      "meta": null,
+                      "sourceSpan": {
+                        "start": [
+                          7,
+                          9
+                        ],
+                        "end": [
+                          7,
+                          30
+                        ]
+                      }
+                    },
+                    "argument": {
+                      "annotation": {
+                        "meta": null,
+                        "sourceSpan": {
+                          "start": [
+                            7,
+                            21
+                          ],
+                          "end": [
+                            7,
+                            30
+                          ]
+                        }
+                      },
+                      "argument": {
+                        "annotation": {
+                          "meta": null,
+                          "sourceSpan": {
+                            "start": [
+                              7,
+                              26
+                            ],
+                            "end": [
+                              7,
+                              29
+                            ]
+                          }
+                        },
+                        "argument": {
+                          "annotation": {
+                            "meta": null,
+                            "sourceSpan": {
+                              "start": [
+                                7,
+                                28
+                              ],
+                              "end": [
+                                7,
+                                29
+                              ]
+                            }
+                          },
+                          "value": {
+                            "literalType": "IntLiteral",
+                            "value": 2
+                          },
+                          "type": "Literal"
+                        },
+                        "type": "App",
+                        "abstraction": {
+                          "annotation": {
+                            "meta": null,
+                            "sourceSpan": {
+                              "start": [
+                                7,
+                                26
+                              ],
+                              "end": [
+                                7,
+                                29
+                              ]
+                            }
+                          },
+                          "argument": {
+                            "annotation": {
+                              "meta": null,
+                              "sourceSpan": {
+                                "start": [
+                                  7,
+                                  26
+                                ],
+                                "end": [
+                                  7,
+                                  27
+                                ]
+                              }
+                            },
+                            "value": {
+                              "moduleName": null,
+                              "identifier": "n"
+                            },
+                            "type": "Var"
+                          },
+                          "type": "App",
+                          "abstraction": {
+                            "annotation": {
+                              "meta": null,
+                              "sourceSpan": {
+                                "start": [
+                                  7,
+                                  26
+                                ],
+                                "end": [
+                                  7,
+                                  29
+                                ]
+                              }
+                            },
+                            "argument": {
+                              "annotation": {
+                                "meta": null,
+                                "sourceSpan": {
+                                  "start": [
+                                    0,
+                                    0
+                                  ],
+                                  "end": [
+                                    0,
+                                    0
+                                  ]
+                                }
+                              },
+                              "value": {
+                                "moduleName": [
+                                  "Data",
+                                  "Ring"
+                                ],
+                                "identifier": "ringInt"
+                              },
+                              "type": "Var"
+                            },
+                            "type": "App",
+                            "abstraction": {
+                              "annotation": {
+                                "meta": {
+                                  "metaType": "IsForeign"
+                                },
+                                "sourceSpan": {
+                                  "start": [
+                                    7,
+                                    27
+                                  ],
+                                  "end": [
+                                    7,
+                                    28
+                                  ]
+                                }
+                              },
+                              "value": {
+                                "moduleName": [
+                                  "Data",
+                                  "Ring"
+                                ],
+                                "identifier": "sub"
+                              },
+                              "type": "Var"
+                            }
+                          }
+                        }
+                      },
+                      "type": "App",
+                      "abstraction": {
+                        "annotation": {
+                          "meta": null,
+                          "sourceSpan": {
+                            "start": [
+                              7,
+                              21
+                            ],
+                            "end": [
+                              7,
+                              24
+                            ]
+                          }
+                        },
+                        "value": {
+                          "moduleName": [
+                            "PureScmTest",
+                            "Fib"
+                          ],
+                          "identifier": "fib"
+                        },
+                        "type": "Var"
+                      }
+                    },
+                    "type": "App",
+                    "abstraction": {
+                      "annotation": {
+                        "meta": null,
+                        "sourceSpan": {
+                          "start": [
+                            7,
+                            9
+                          ],
+                          "end": [
+                            7,
+                            30
+                          ]
+                        }
+                      },
+                      "argument": {
+                        "annotation": {
+                          "meta": null,
+                          "sourceSpan": {
+                            "start": [
+                              7,
+                              9
+                            ],
+                            "end": [
+                              7,
+                              18
+                            ]
+                          }
+                        },
+                        "argument": {
+                          "annotation": {
+                            "meta": null,
+                            "sourceSpan": {
+                              "start": [
+                                7,
+                                14
+                              ],
+                              "end": [
+                                7,
+                                17
+                              ]
+                            }
+                          },
+                          "argument": {
+                            "annotation": {
+                              "meta": null,
+                              "sourceSpan": {
+                                "start": [
+                                  7,
+                                  16
+                                ],
+                                "end": [
+                                  7,
+                                  17
+                                ]
+                              }
+                            },
+                            "value": {
+                              "literalType": "IntLiteral",
+                              "value": 1
+                            },
+                            "type": "Literal"
+                          },
+                          "type": "App",
+                          "abstraction": {
+                            "annotation": {
+                              "meta": null,
+                              "sourceSpan": {
+                                "start": [
+                                  7,
+                                  14
+                                ],
+                                "end": [
+                                  7,
+                                  17
+                                ]
+                              }
+                            },
+                            "argument": {
+                              "annotation": {
+                                "meta": null,
+                                "sourceSpan": {
+                                  "start": [
+                                    7,
+                                    14
+                                  ],
+                                  "end": [
+                                    7,
+                                    15
+                                  ]
+                                }
+                              },
+                              "value": {
+                                "moduleName": null,
+                                "identifier": "n"
+                              },
+                              "type": "Var"
+                            },
+                            "type": "App",
+                            "abstraction": {
+                              "annotation": {
+                                "meta": null,
+                                "sourceSpan": {
+                                  "start": [
+                                    7,
+                                    14
+                                  ],
+                                  "end": [
+                                    7,
+                                    17
+                                  ]
+                                }
+                              },
+                              "argument": {
+                                "annotation": {
+                                  "meta": null,
+                                  "sourceSpan": {
+                                    "start": [
+                                      0,
+                                      0
+                                    ],
+                                    "end": [
+                                      0,
+                                      0
+                                    ]
+                                  }
+                                },
+                                "value": {
+                                  "moduleName": [
+                                    "Data",
+                                    "Ring"
+                                  ],
+                                  "identifier": "ringInt"
+                                },
+                                "type": "Var"
+                              },
+                              "type": "App",
+                              "abstraction": {
+                                "annotation": {
+                                  "meta": {
+                                    "metaType": "IsForeign"
+                                  },
+                                  "sourceSpan": {
+                                    "start": [
+                                      7,
+                                      15
+                                    ],
+                                    "end": [
+                                      7,
+                                      16
+                                    ]
+                                  }
+                                },
+                                "value": {
+                                  "moduleName": [
+                                    "Data",
+                                    "Ring"
+                                  ],
+                                  "identifier": "sub"
+                                },
+                                "type": "Var"
+                              }
+                            }
+                          }
+                        },
+                        "type": "App",
+                        "abstraction": {
+                          "annotation": {
+                            "meta": null,
+                            "sourceSpan": {
+                              "start": [
+                                7,
+                                9
+                              ],
+                              "end": [
+                                7,
+                                12
+                              ]
+                            }
+                          },
+                          "value": {
+                            "moduleName": [
+                              "PureScmTest",
+                              "Fib"
+                            ],
+                            "identifier": "fib"
+                          },
+                          "type": "Var"
+                        }
+                      },
+                      "type": "App",
+                      "abstraction": {
+                        "annotation": {
+                          "meta": null,
+                          "sourceSpan": {
+                            "start": [
+                              7,
+                              9
+                            ],
+                            "end": [
+                              7,
+                              30
+                            ]
+                          }
+                        },
+                        "argument": {
+                          "annotation": {
+                            "meta": null,
+                            "sourceSpan": {
+                              "start": [
+                                0,
+                                0
+                              ],
+                              "end": [
+                                0,
+                                0
+                              ]
+                            }
+                          },
+                          "value": {
+                            "moduleName": [
+                              "Data",
+                              "Semiring"
+                            ],
+                            "identifier": "semiringInt"
+                          },
+                          "type": "Var"
+                        },
+                        "type": "App",
+                        "abstraction": {
+                          "annotation": {
+                            "meta": {
+                              "metaType": "IsForeign"
+                            },
+                            "sourceSpan": {
+                              "start": [
+                                7,
+                                19
+                              ],
+                              "end": [
+                                7,
+                                20
+                              ]
+                            }
+                          },
+                          "value": {
+                            "moduleName": [
+                              "Data",
+                              "Semiring"
+                            ],
+                            "identifier": "add"
+                          },
+                          "type": "Var"
+                        }
+                      }
+                    }
+                  },
+                  "isGuarded": false
+                }
+              ],
+              "type": "Case"
+            },
+            "argument": "v",
+            "type": "Abs"
+          }
+        }
+      ],
+      "bindType": "Rec"
+    }
+  ],
+  "comments": [],
+  "foreign": [],
+  "sourceSpan": {
+    "start": [
+      1,
+      1
+    ],
+    "end": [
+      7,
+      30
+    ]
+  }
+}

--- a/resources/PureScmTest.Fib.purs
+++ b/resources/PureScmTest.Fib.purs
@@ -1,0 +1,7 @@
+module PureScmTest.Fib where
+
+import Prelude
+
+fib 0 = 0
+fib 1 = 1
+fib n = fib (n-1) + fib (n-2)

--- a/src/Language/PureScript/Scheme/CodeGen/AST.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/AST.hs
@@ -27,15 +27,30 @@ data AST
   -- information.
   | VectorLiteral [AST]
 
-  -- | Variable.
+  -- | Bound variable reference.
+  -- Any identifier appearing as an expression in a program is a variable if a
+  -- visible variable binding for the identifier exists.
+  -- Check The Scheme Programming Language Fourth Edition Chapter 4.1 for more
+  -- information.
   | Identifier Text
 
+  -- | Cond expression.
+  -- The argument is a list of pairs (clauses) where the first expression is
+  -- the condition and the second expression is the result.
   | Cond [(AST, AST)]
 
-  -- | Function application.
+  -- | Procedure application.
+  -- The first argument is an expression resulting to a procedure.
+  -- The first argument is the list of actual parameters to be applied.
   | Application AST [AST]
 
-  -- | Lambda form.
+  -- | Lambda abstraction.
+  -- To match the semantics of PureScript, lambdas with only a single argument
+  -- are allowed for now.
+  -- The first argiment of this data type is the formal parameter of the lambda,
+  -- which is an unbound or bound identifier. We're using Text for simplicity.
+  -- Check The Scheme Programming Language Fourth Edition Chapter 4.2 for more
+  -- information.
   | Lambda Text AST
 
   -- | Variable definition.

--- a/src/Language/PureScript/Scheme/CodeGen/AST.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/AST.hs
@@ -27,6 +27,17 @@ data AST
   -- information.
   | VectorLiteral [AST]
 
+  -- | Variable.
+  | Identifier Text
+
+  | Cond [(AST, AST)]
+
+  -- | Function application.
+  | Application AST [AST]
+
+  -- | Lambda form.
+  | Lambda Text AST
+
   -- | Variable definition.
   -- In Scheme there are two define syntax:
   --   - Simple variable definition: (define var expr). This expression binds

--- a/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
@@ -3,6 +3,8 @@ module Language.PureScript.Scheme.CodeGen.Optimizer where
 import Language.PureScript.Scheme.CodeGen.AST (AST(..))
 
 
+-- Single pass optimizer.
+-- Run through all the AST expressions and apply the optimizations.
 runOptimizations :: [AST] -> [AST]
 runOptimizations xs = map (\x -> everywhere specializeOperators x) xs
 
@@ -21,6 +23,7 @@ specializeOperators (Application (Application (Application (Identifier "Data.Rin
 specializeOperators ast = ast
 
 
+-- | Recursively apply f to each AST.
 everywhere :: (AST -> AST) -> AST -> AST
 everywhere f = go where
   go :: AST -> AST

--- a/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
@@ -1,0 +1,32 @@
+module Language.PureScript.Scheme.CodeGen.Optimizer where
+
+import Language.PureScript.Scheme.CodeGen.AST (AST(..))
+
+
+runOptimizations :: [AST] -> [AST]
+runOptimizations xs = map (\x -> everywhere specializeOperators x) xs
+
+
+-- TODO: possibly nasty hack. To review once externs are implemented.
+specializeOperators :: AST -> AST
+
+specializeOperators (Application (Application (Application (Identifier "Data.Semiring.add")
+                                 [Identifier "Data.Semiring.semiringInt"]) [x]) [y])
+  = Application (Identifier "+") [x, y]
+
+specializeOperators (Application (Application (Application (Identifier "Data.Ring.sub")
+                                 [Identifier "Data.Ring.ringInt"]) [x]) [y])
+  = Application (Identifier "-") [x, y]
+
+specializeOperators ast = ast
+
+
+everywhere :: (AST -> AST) -> AST -> AST
+everywhere f = go where
+  go :: AST -> AST
+  go (VectorLiteral xs) = f (VectorLiteral (map go xs))
+  go (Cond xs) = f (Cond (map (\(test, expr) -> (go test, go expr)) xs))
+  go (Application function args) = f (Application (go function) (map go args))
+  go (Lambda arg expr) = f (Lambda arg (go expr))
+  go (Define name expr) = f (Define name (go expr))
+  go other = f other

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -12,15 +12,28 @@ parens x = "(" <> x <> ")"
 list :: [Text] -> Text
 list xs = parens $ intercalate " " xs
 
-define :: Text -> Text -> Text
-define name expr = list ["define", name, expr]
-
 vector :: [Text] -> Text
 vector xs = list ("vector" : xs)
+
+cond :: [Text] -> Text
+cond xs = list ("cond" : xs)
+
+application :: Text -> [Text] -> Text
+application function args = list (function : args)
+
+lambda :: Text -> Text -> Text
+lambda parameter expr = list ["lambda", list [parameter], expr]
+
+define :: Text -> Text -> Text
+define name expr = list ["define", name, expr]
 
 emit :: AST -> Text
 emit (IntegerLiteral integer) = tshow integer
 emit (VectorLiteral xs) = vector (fmap emit xs)
+emit (Identifier x) = x
+emit (Cond xs) = cond $ fmap (\(test, expr) -> list [emit test, emit expr]) xs
+emit (Application function args) = application (emit function) (fmap emit args)
+emit (Lambda arg expr) = lambda arg (emit expr)
 emit (Define name expr) = define name (emit expr)
 
 printScheme :: [AST] -> Text

--- a/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
@@ -2,8 +2,10 @@ module Language.PureScript.Scheme.CodeGen.Transpiler where
 
 import Language.PureScript.CoreFn.Module      (Module(..))
 import Language.PureScript.CoreFn.Ann         (Ann)
-import Language.PureScript.CoreFn.Expr        (Expr(..), Bind(..))
-import Language.PureScript.Names              (runIdent)
+import Language.PureScript.CoreFn.Expr        (Expr(..), Bind(..), Guard,
+                                               CaseAlternative(..))
+import Language.PureScript.CoreFn.Binders     (Binder(..))
+import Language.PureScript.Names              (runIdent, showQualified)
 import Language.PureScript.AST.Literals       (Literal(..))
 import Language.PureScript.Scheme.CodeGen.AST (AST(..))
 
@@ -15,13 +17,32 @@ moduleToScheme (Module _sourceSpan _comments _name _path
 
 
 bindToScheme :: Bind Ann -> AST
+
 bindToScheme (NonRec _ann ident expr) =
   Define (runIdent ident) (exprToScheme expr)
-bindToScheme _ = error "Not implemented"
+
+-- TODO: handle multiple definitions
+-- in Scheme mapping each (ident, expr) to a single new define should be enough.
+-- In order to do so we have to change the return signature from AST to [AST].
+bindToScheme (Rec xs) =
+  let ((_ann, ident), expr) = xs !! 0 in
+    Define (runIdent ident) (exprToScheme expr)
 
 
 exprToScheme :: Expr Ann -> AST
+
 exprToScheme (Literal _ann literal) = literalToScheme literal
+
+exprToScheme (Var _ann qualifiedIdent) = Identifier (showQualified runIdent qualifiedIdent)
+
+exprToScheme (Case _ann values caseAlternatives) =
+  caseAlternativesToScheme values caseAlternatives
+
+exprToScheme (Abs _ann arg expr) = Lambda (runIdent arg) (exprToScheme expr)
+
+exprToScheme (App _ann function arg) =
+  Application (exprToScheme function) [exprToScheme arg]
+
 exprToScheme _ = error "Not implemented"
 
 
@@ -29,3 +50,55 @@ literalToScheme :: Literal (Expr Ann) -> AST
 literalToScheme (NumericLiteral (Left integer)) = IntegerLiteral integer
 literalToScheme (ArrayLiteral xs) = VectorLiteral $ fmap exprToScheme xs
 literalToScheme _ = error "Not implemented"
+
+
+-- From:
+-- [Value1, Value2, Value3]
+-- [CaseAlternativeA{binders=[BinderA1, BinderA2, BinderA3],
+--                   result=ResA},
+--  CaseAlternativeB{binders=[BinderB1, BinderB2, BinderB3],
+--                  result=ResB}]
+--
+-- To:
+-- [([(Value1, BinderA1), (Value2, BinderA2), (Value3, BinderA3)], ResA),
+--  ([(Value1, BinderB1), (Value2, BinderB2), (Value3, BinderB3)], ResB)]
+straightenCaseAlternatives
+  :: [Expr Ann]
+  -> [CaseAlternative Ann]
+  -> [([(Expr Ann, Binder Ann)], Either [(Guard Ann, Expr Ann)] (Expr Ann))]
+  --     ^Value^^  ^Binder^^^    ^Res^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+straightenCaseAlternatives values caseAlternatives =
+  map (\(CaseAlternative binders result) -> (zip values binders, result))
+      caseAlternatives
+
+
+caseAlternativesToScheme :: [Expr Ann] -> [CaseAlternative Ann] -> AST
+caseAlternativesToScheme values caseAlternatives =
+  let alternatives = straightenCaseAlternatives values caseAlternatives
+  in Cond $ concatMap (\(valuesAndBinders, result) ->
+                         map (\(value, binder) ->
+                                ((unifyBinder value binder),
+                                 case result of
+                                   Left _xs -> error "Not implemented"
+                                   Right expr -> exprToScheme expr))
+                             valuesAndBinders)
+                      alternatives
+
+
+unifyBinder :: Expr Ann -> Binder Ann -> AST
+
+unifyBinder value (LiteralBinder _ann literal) = unifyLiteralBinder value literal
+
+-- TODO: This is possibly a nasty hack to make Cond work.
+-- Check how to properly translate VarBinder.
+unifyBinder _value (VarBinder _ann _ident) = Identifier "else"
+
+unifyBinder _ _ = error "Not implemented"
+
+
+unifyLiteralBinder :: Expr Ann -> Literal (Binder Ann) -> AST
+
+unifyLiteralBinder value (NumericLiteral (Left integer))=
+  Application (Identifier "=") [exprToScheme value, IntegerLiteral integer]
+
+unifyLiteralBinder _ _ = error "Not implemented"


### PR DESCRIPTION
- Add `PureScmTest.Fib` test module
- Add to AST: Identifier, Cond, Application and Lambda
- Extend Printer to emit Identifier, Cond, Application and Lambda
- Extend Transpiler to (sort of) handle Identifier, Cond, Application and Lambda
- Add simple optimizer to specialize sum and subtraction

Now we can compile Fibonacci, but the name resolution produces a wrong identifier for the recursive call.