### PR TITLE
Change AST To S-Expression

### DIFF
--- a/src/Language/PureScript/Scheme/CodeGen/AST.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/AST.hs
@@ -30,15 +30,6 @@ data AST
   -- The first argument is the list of actual parameters to be applied.
   | Application AST [AST]
 
-  -- | Lambda abstraction.
-  -- To match the semantics of PureScript, lambdas with only a single argument
-  -- are allowed for now.
-  -- The first argiment of this data type is the formal parameter of the lambda,
-  -- which is an unbound or bound identifier. We're using Text for simplicity.
-  -- Check The Scheme Programming Language Fourth Edition Chapter 4.2 for more
-  -- information.
-  | Lambda Text AST
-
   -- | Unquoted list.
   | List [AST]
 
@@ -52,5 +43,4 @@ everywhere f = go where
   go (IntegerLiteral i) = f (IntegerLiteral i)
   go (Identifier t) = f (Identifier t)
   go (Application function args) = f (Application (go function) (map go args))
-  go (Lambda arg expr) = f (Lambda arg (go expr))
   go (List xs) = f (List (map go xs))

--- a/src/Language/PureScript/Scheme/CodeGen/AST.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/AST.hs
@@ -18,12 +18,9 @@ data AST
   -- Check Chez Scheme Version 9 User's Guide chapter 8 for more information.
   = IntegerLiteral Integer
 
-  -- | Bound variable reference.
-  -- Any identifier appearing as an expression in a program is a variable if a
-  -- visible variable binding for the identifier exists.
-  -- Check The Scheme Programming Language Fourth Edition Chapter 4.1 for more
-  -- information.
-  | Identifier Text
+  -- | An unquoted symbol.
+  -- E.g. in `(lambda (x) (+ x 1))': `lambda', `x' and `+' are symbols.
+  | Symbol Text
 
   -- | Unquoted list.
   | List [AST]
@@ -36,5 +33,5 @@ everywhere :: (AST -> AST) -> AST -> AST
 everywhere f = go where
   go :: AST -> AST
   go (IntegerLiteral i) = f (IntegerLiteral i)
-  go (Identifier t) = f (Identifier t)
+  go (Symbol t) = f (Symbol t)
   go (List xs) = f (List (map go xs))

--- a/src/Language/PureScript/Scheme/CodeGen/AST.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/AST.hs
@@ -25,11 +25,6 @@ data AST
   -- information.
   | Identifier Text
 
-  -- | Procedure application.
-  -- The first argument is an expression resulting to a procedure.
-  -- The first argument is the list of actual parameters to be applied.
-  | Application AST [AST]
-
   -- | Unquoted list.
   | List [AST]
 
@@ -42,5 +37,4 @@ everywhere f = go where
   go :: AST -> AST
   go (IntegerLiteral i) = f (IntegerLiteral i)
   go (Identifier t) = f (Identifier t)
-  go (Application function args) = f (Application (go function) (map go args))
   go (List xs) = f (List (map go xs))

--- a/src/Language/PureScript/Scheme/CodeGen/AST.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/AST.hs
@@ -39,20 +39,6 @@ data AST
   -- information.
   | Lambda Text AST
 
-  -- | Variable definition.
-  -- In Scheme there are two define syntax:
-  --   - Simple variable definition: (define var expr). This expression binds
-  --     var to expr.
-  --   - Unspecified definition: (define var)
-  --   - Procedure definition:
-  --       - (define (var0 var1 ...) body1 body2 ...)
-  --       - (define (var0 . vars) body1 body2 ...)
-  --       - (define (var0 var1 ... . vars) body1 body2)
-  -- This data construtor expresses a simple variable definition.
-  -- Check The Scheme Programming Language Fourth Edition Chapter 4.6 for more
-  -- information.
-  | Define Text AST
-
   -- | Unquoted list.
   | List [AST]
 
@@ -67,5 +53,4 @@ everywhere f = go where
   go (Identifier t) = f (Identifier t)
   go (Application function args) = f (Application (go function) (map go args))
   go (Lambda arg expr) = f (Lambda arg (go expr))
-  go (Define name expr) = f (Define name (go expr))
   go (List xs) = f (List (map go xs))

--- a/src/Language/PureScript/Scheme/CodeGen/AST.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/AST.hs
@@ -25,11 +25,6 @@ data AST
   -- information.
   | Identifier Text
 
-  -- | Cond expression.
-  -- The argument is a list of pairs (clauses) where the first expression is
-  -- the condition and the second expression is the result.
-  | Cond [(AST, AST)]
-
   -- | Procedure application.
   -- The first argument is an expression resulting to a procedure.
   -- The first argument is the list of actual parameters to be applied.
@@ -58,6 +53,9 @@ data AST
   -- information.
   | Define Text AST
 
+  -- | Unquoted list.
+  | List [AST]
+
   deriving (Show)
 
 
@@ -67,7 +65,7 @@ everywhere f = go where
   go :: AST -> AST
   go (IntegerLiteral i) = f (IntegerLiteral i)
   go (Identifier t) = f (Identifier t)
-  go (Cond xs) = f (Cond (map (\(test, expr) -> (go test, go expr)) xs))
   go (Application function args) = f (Application (go function) (map go args))
   go (Lambda arg expr) = f (Lambda arg (go expr))
   go (Define name expr) = f (Define name (go expr))
+  go (List xs) = f (List (map go xs))

--- a/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
@@ -1,21 +1,21 @@
 module Language.PureScript.Scheme.CodeGen.Optimizer where
 
-import Language.PureScript.Scheme.CodeGen.AST (AST(..), everywhere)
+import Language.PureScript.Scheme.CodeGen.SExpr (SExpr(..), everywhere)
 import Language.PureScript.Scheme.CodeGen.Scheme (app)
 
 
-optimizations :: AST -> AST
+optimizations :: SExpr -> SExpr
 optimizations = (simplifyLogic . specializeOperators)
 
 
 -- Single pass optimizer.
--- Run through all the AST expressions and apply the optimizations.
-runOptimizations :: [AST] -> [AST]
+-- Run through all the SExpr expressions and apply the optimizations.
+runOptimizations :: [SExpr] -> [SExpr]
 runOptimizations xs = map (\x -> everywhere optimizations x) xs
 
 
 -- TODO: possibly nasty hack. To review once externs are implemented.
-specializeOperators :: AST -> AST
+specializeOperators :: SExpr -> SExpr
 
 specializeOperators (List [List [List [Symbol "Data.Semiring.add",
                                        Symbol "Data.Semiring.semiringInt"],
@@ -34,7 +34,7 @@ specializeOperators ast = ast
 -- Reduce (and x #t y) to (and x y)
 -- Reduce (and x) to x
 -- TODO: write a test
-simplifyLogic :: AST -> AST
+simplifyLogic :: SExpr -> SExpr
 simplifyLogic (List ((Symbol "and"):args)) =
   let
     go ((Symbol "#t") : xs) = go xs

--- a/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Optimizer.hs
@@ -17,13 +17,13 @@ runOptimizations xs = map (\x -> everywhere optimizations x) xs
 -- TODO: possibly nasty hack. To review once externs are implemented.
 specializeOperators :: AST -> AST
 
-specializeOperators (List [List [List [Identifier "Data.Semiring.add",
-                                       Identifier "Data.Semiring.semiringInt"],
+specializeOperators (List [List [List [Symbol "Data.Semiring.add",
+                                       Symbol "Data.Semiring.semiringInt"],
                            x], y])
   = app "+" [x, y]
 
-specializeOperators (List [List [List [Identifier "Data.Ring.sub",
-                                       Identifier "Data.Ring.ringInt"],
+specializeOperators (List [List [List [Symbol "Data.Ring.sub",
+                                       Symbol "Data.Ring.ringInt"],
                                   x], y])
   = app "-" [x, y]
 
@@ -35,14 +35,14 @@ specializeOperators ast = ast
 -- Reduce (and x) to x
 -- TODO: write a test
 simplifyLogic :: AST -> AST
-simplifyLogic (List ((Identifier "and"):args)) =
+simplifyLogic (List ((Symbol "and"):args)) =
   let
-    go ((Identifier "#t") : xs) = go xs
+    go ((Symbol "#t") : xs) = go xs
     go (x : xs) = (x : go xs)
     go [] = []
   in
     case go args of
-      [] -> Identifier "#t"
+      [] -> Symbol "#t"
       [x]  -> x
       xs -> app "and" xs
 

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -1,7 +1,7 @@
 module Language.PureScript.Scheme.CodeGen.Printer where
 
-import Data.Text                              (Text, pack, intercalate)
-import Language.PureScript.Scheme.CodeGen.AST (AST(..))
+import Data.Text (Text, pack, intercalate)
+import Language.PureScript.Scheme.CodeGen.SExpr (SExpr(..))
 
 tshow :: Show a => a -> Text
 tshow = pack . show
@@ -12,10 +12,10 @@ parens x = "(" <> x <> ")"
 list :: [Text] -> Text
 list xs = parens $ intercalate " " xs
 
-emit :: AST -> Text
+emit :: SExpr -> Text
 emit (IntegerLiteral integer) = tshow integer
 emit (Symbol x) = x
 emit (List xs) = list $ map emit xs
 
-printScheme :: [AST] -> Text
+printScheme :: [SExpr] -> Text
 printScheme xs = intercalate "\n\n" (fmap emit xs)

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -14,7 +14,7 @@ list xs = parens $ intercalate " " xs
 
 emit :: AST -> Text
 emit (IntegerLiteral integer) = tshow integer
-emit (Identifier x) = x
+emit (Symbol x) = x
 emit (List xs) = list $ map emit xs
 
 printScheme :: [AST] -> Text

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -12,16 +12,9 @@ parens x = "(" <> x <> ")"
 list :: [Text] -> Text
 list xs = parens $ intercalate " " xs
 
-cond :: [Text] -> Text
-cond xs = list ("cond" : xs)
-
-application :: Text -> [Text] -> Text
-application function args = list (function : args)
-
 emit :: AST -> Text
 emit (IntegerLiteral integer) = tshow integer
 emit (Identifier x) = x
-emit (Application function args) = application (emit function) (fmap emit args)
 emit (List xs) = list $ map emit xs
 
 printScheme :: [AST] -> Text

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -21,15 +21,11 @@ application function args = list (function : args)
 lambda :: Text -> Text -> Text
 lambda parameter expr = list ["lambda", list [parameter], expr]
 
-define :: Text -> Text -> Text
-define name expr = list ["define", name, expr]
-
 emit :: AST -> Text
 emit (IntegerLiteral integer) = tshow integer
 emit (Identifier x) = x
 emit (Application function args) = application (emit function) (fmap emit args)
 emit (Lambda arg expr) = lambda arg (emit expr)
-emit (Define name expr) = define name (emit expr)
 emit (List xs) = list $ map emit xs
 
 printScheme :: [AST] -> Text

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -31,6 +31,7 @@ emit (Cond xs) = cond $ fmap (\(test, expr) -> list [emit test, emit expr]) xs
 emit (Application function args) = application (emit function) (fmap emit args)
 emit (Lambda arg expr) = lambda arg (emit expr)
 emit (Define name expr) = define name (emit expr)
+emit (List xs) = list $ map emit xs
 
 printScheme :: [AST] -> Text
 printScheme xs = intercalate "\n\n" (fmap emit xs)

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -27,7 +27,6 @@ define name expr = list ["define", name, expr]
 emit :: AST -> Text
 emit (IntegerLiteral integer) = tshow integer
 emit (Identifier x) = x
-emit (Cond xs) = cond $ fmap (\(test, expr) -> list [emit test, emit expr]) xs
 emit (Application function args) = application (emit function) (fmap emit args)
 emit (Lambda arg expr) = lambda arg (emit expr)
 emit (Define name expr) = define name (emit expr)

--- a/src/Language/PureScript/Scheme/CodeGen/Printer.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Printer.hs
@@ -18,14 +18,10 @@ cond xs = list ("cond" : xs)
 application :: Text -> [Text] -> Text
 application function args = list (function : args)
 
-lambda :: Text -> Text -> Text
-lambda parameter expr = list ["lambda", list [parameter], expr]
-
 emit :: AST -> Text
 emit (IntegerLiteral integer) = tshow integer
 emit (Identifier x) = x
 emit (Application function args) = application (emit function) (fmap emit args)
-emit (Lambda arg expr) = lambda arg (emit expr)
 emit (List xs) = list $ map emit xs
 
 printScheme :: [AST] -> Text

--- a/src/Language/PureScript/Scheme/CodeGen/SExpr.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/SExpr.hs
@@ -1,9 +1,9 @@
-module Language.PureScript.Scheme.CodeGen.AST where
+module Language.PureScript.Scheme.CodeGen.SExpr where
 
 import Data.Text (Text)
 
 -- | Data type for Scheme expression
-data AST
+data SExpr
 
   -- | Integer literal.
   -- Chez Scheme uses two distinct types for integers:
@@ -23,15 +23,15 @@ data AST
   | Symbol Text
 
   -- | Unquoted list.
-  | List [AST]
+  | List [SExpr]
 
   deriving (Show)
 
 
--- | Recursively apply f to each AST.
-everywhere :: (AST -> AST) -> AST -> AST
+-- | Recursively apply f to each SExpr.
+everywhere :: (SExpr -> SExpr) -> SExpr -> SExpr
 everywhere f = go where
-  go :: AST -> AST
+  go :: SExpr -> SExpr
   go (IntegerLiteral i) = f (IntegerLiteral i)
   go (Symbol t) = f (Symbol t)
   go (List xs) = f (List (map go xs))

--- a/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
@@ -21,6 +21,13 @@ t = Identifier "#t"
 define :: Text -> AST -> AST
 define name expr = List [Identifier "define", Identifier name, expr]
 
+lambda :: [Text] -> AST -> AST
+lambda formals expr =
+  List [Identifier "lambda", List $ map Identifier formals, expr]
+
+lambda1 :: Text -> AST -> AST
+lambda1 formal expr = lambda [formal] expr
+
 
 -- Scheme functions ------------------------------------------------------------
 

--- a/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
@@ -1,67 +1,67 @@
 module Language.PureScript.Scheme.CodeGen.Scheme where
 
-import Data.Text                              (Text)
-import Language.PureScript.Scheme.CodeGen.AST (AST(..))
+import Data.Text (Text)
+import Language.PureScript.Scheme.CodeGen.SExpr (SExpr(..))
 
 
 -- Helpers ---------------------------------------------------------------------
 
-app :: Text -> [AST] -> AST
+app :: Text -> [SExpr] -> SExpr
 app name args = List ((Symbol name):args)
 
 
 -- Scheme symbols --------------------------------------------------------------
 
-t :: AST
+t :: SExpr
 t = Symbol "#t"
 
 
 -- Scheme special forms --------------------------------------------------------
 
-define :: Text -> AST -> AST
+define :: Text -> SExpr -> SExpr
 define name expr = List [Symbol "define", Symbol name, expr]
 
-lambda :: [Text] -> AST -> AST
+lambda :: [Text] -> SExpr -> SExpr
 lambda formals expr =
   List [Symbol "lambda", List $ map Symbol formals, expr]
 
-lambda1 :: Text -> AST -> AST
+lambda1 :: Text -> SExpr -> SExpr
 lambda1 formal expr = lambda [formal] expr
 
 
 -- Scheme functions ------------------------------------------------------------
 
-eq :: [AST] -> AST
+eq :: [SExpr] -> SExpr
 eq xs = app "=" xs
 
-eqQ :: AST -> AST -> AST
+eqQ :: SExpr -> SExpr -> SExpr
 eqQ x y = app "eq?" [x, y]
 
-and_ :: [AST] -> AST
+and_ :: [SExpr] -> SExpr
 and_ xs = app "and" xs
 
-quote :: AST -> AST
+quote :: SExpr -> SExpr
 quote x = app "quote" [x]
 
-cons :: AST -> AST -> AST
+cons :: SExpr -> SExpr -> SExpr
 cons x y = app "cons" [x, y]
 
-car :: AST -> AST
+car :: SExpr -> SExpr
 car l = app "car" [l]
 
-cdr :: AST -> AST
+cdr :: SExpr -> SExpr
 cdr l = app "cdr" [l]
 
 -- (cond (test expr) ... (else expr))
-cond :: [(AST, AST)] -> AST -> AST
+cond :: [(SExpr, SExpr)] -> SExpr -> SExpr
 cond clauses elseExpr = cond' (clauses ++ [(Symbol "else", elseExpr)])
 
 -- (cond (test expr) ...)
-cond' :: [(AST, AST)] -> AST
+cond' :: [(SExpr, SExpr)] -> SExpr
 cond' clauses = app "cond" $ map (\(test, expr) -> List [test, expr]) clauses
 
-vector :: [AST] -> AST
+vector :: [SExpr] -> SExpr
 vector xs = app "vector" xs
 
-vectorRef :: AST -> AST -> AST
+vectorRef :: SExpr -> SExpr -> SExpr
 vectorRef v i = app "vector-ref" [v, i]

--- a/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
@@ -7,7 +7,7 @@ import Language.PureScript.Scheme.CodeGen.AST (AST(..))
 -- Helpers ---------------------------------------------------------------------
 
 app :: Text -> [AST] -> AST
-app name args = Application (Identifier name) args
+app name args = List ((Identifier name):args)
 
 
 -- Scheme symbols --------------------------------------------------------------

--- a/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
@@ -7,23 +7,23 @@ import Language.PureScript.Scheme.CodeGen.AST (AST(..))
 -- Helpers ---------------------------------------------------------------------
 
 app :: Text -> [AST] -> AST
-app name args = List ((Identifier name):args)
+app name args = List ((Symbol name):args)
 
 
 -- Scheme symbols --------------------------------------------------------------
 
 t :: AST
-t = Identifier "#t"
+t = Symbol "#t"
 
 
 -- Scheme special forms --------------------------------------------------------
 
 define :: Text -> AST -> AST
-define name expr = List [Identifier "define", Identifier name, expr]
+define name expr = List [Symbol "define", Symbol name, expr]
 
 lambda :: [Text] -> AST -> AST
 lambda formals expr =
-  List [Identifier "lambda", List $ map Identifier formals, expr]
+  List [Symbol "lambda", List $ map Symbol formals, expr]
 
 lambda1 :: Text -> AST -> AST
 lambda1 formal expr = lambda [formal] expr
@@ -54,7 +54,7 @@ cdr l = app "cdr" [l]
 
 -- (cond (test expr) ... (else expr))
 cond :: [(AST, AST)] -> AST -> AST
-cond clauses elseExpr = cond' (clauses ++ [(Identifier "else", elseExpr)])
+cond clauses elseExpr = cond' (clauses ++ [(Symbol "else", elseExpr)])
 
 -- (cond (test expr) ...)
 cond' :: [(AST, AST)] -> AST

--- a/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
@@ -16,6 +16,12 @@ t :: AST
 t = Identifier "#t"
 
 
+-- Scheme special forms --------------------------------------------------------
+
+define :: Text -> AST -> AST
+define name expr = List [Identifier "define", Identifier name, expr]
+
+
 -- Scheme functions ------------------------------------------------------------
 
 eq :: [AST] -> AST

--- a/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Scheme.hs
@@ -39,6 +39,14 @@ car l = app "car" [l]
 cdr :: AST -> AST
 cdr l = app "cdr" [l]
 
+-- (cond (test expr) ... (else expr))
+cond :: [(AST, AST)] -> AST -> AST
+cond clauses elseExpr = cond' (clauses ++ [(Identifier "else", elseExpr)])
+
+-- (cond (test expr) ...)
+cond' :: [(AST, AST)] -> AST
+cond' clauses = app "cond" $ map (\(test, expr) -> List [test, expr]) clauses
+
 vector :: [AST] -> AST
 vector xs = app "vector" xs
 

--- a/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
@@ -12,6 +12,7 @@ import Language.PureScript.AST.Literals          (Literal(..))
 import Language.PureScript.Scheme.Util           (mapWithIndex, concatMapWithIndex)
 import Language.PureScript.Scheme.CodeGen.AST    (AST(..), everywhere)
 import Language.PureScript.Scheme.CodeGen.Scheme (t,
+                                                  define,
                                                   eq, eqQ, and_, quote,
                                                   cons, car, cdr, cond',
                                                   vector, vectorRef)
@@ -25,9 +26,9 @@ moduleToScheme (Module _sourceSpan _comments _name _path
 
 topLevelBindToScheme :: Bind Ann -> [AST]
 topLevelBindToScheme (NonRec _ann ident expr) =
-  [Define (runIdent ident) (exprToScheme expr)]
+  [define (runIdent ident) (exprToScheme expr)]
 topLevelBindToScheme (Rec xs) =
-  [ Define (runIdent ident) (exprToScheme expr)
+  [ define (runIdent ident) (exprToScheme expr)
   | ((_ann, ident), expr) <- xs ]
 
 

--- a/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
@@ -66,11 +66,11 @@ exprToScheme (Constructor _ann _typeName constructorName fields) =
   go fields
   where
     go (x:xs) = lambda1 (runIdent x) (go xs)
-    go [] = cons (quote (Identifier (runProperName constructorName)))
-                 (vector (fmap (\field -> Identifier (runIdent field)) fields))
+    go [] = cons (quote (Symbol (runProperName constructorName)))
+                 (vector (fmap (\field -> Symbol (runIdent field)) fields))
 
 exprToScheme (Var _ann qualifiedIdent) =
-  Identifier (showQualified runIdent qualifiedIdent)
+  Symbol (showQualified runIdent qualifiedIdent)
 
 -- `values' holds the values we're matching against, for instance it could be
 -- a list of Vars where each Var is the LHS of the pattern matching. For instance
@@ -204,7 +204,7 @@ caseToScheme values caseAlternatives =
     --     (= (vector-ref (cdr v) 0) 1)
     binderToTest value (ConstructorBinder _ann _typeName constructorName binders) =
       (:) (eqQ (car value)
-               (quote (Identifier (runProperName (disqualify constructorName)))))
+               (quote (Symbol (runProperName (disqualify constructorName)))))
           (concatMapWithIndex
            (\i b -> (binderToTest (vectorRef (cdr value) (IntegerLiteral i)) b))
            binders)
@@ -277,11 +277,11 @@ caseToScheme values caseAlternatives =
         go' _ = error "Not implemented"
 
 
--- Replace each (Identifier from) into a `to' AST everywhere in ast
+-- Replace each (Symbol from) into a `to' AST everywhere in ast
 replaceVariables :: AST -> [(Text, AST)] -> AST
 replaceVariables ast mapping = everywhere (go mapping) ast
   where
-    go ((from, to):xs) (Identifier i) =
-      if i == from then to else go xs (Identifier i) 
+    go ((from, to):xs) (Symbol i) =
+      if i == from then to else go xs (Symbol i)
     go [] ast' = ast'
     go _xs ast' = ast'

--- a/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
@@ -13,7 +13,7 @@ import Language.PureScript.Scheme.Util           (mapWithIndex, concatMapWithInd
 import Language.PureScript.Scheme.CodeGen.AST    (AST(..), everywhere)
 import Language.PureScript.Scheme.CodeGen.Scheme (t,
                                                   eq, eqQ, and_, quote,
-                                                  cons, car, cdr,
+                                                  cons, car, cdr, cond',
                                                   vector, vectorRef)
 
 -- TODO: translate a PureScript module to a Scheme library instead.
@@ -116,7 +116,7 @@ straightenCaseExpr values caseAlternatives =
 
 caseToScheme :: [Expr Ann] -> [CaseAlternative Ann] -> AST
 caseToScheme values caseAlternatives =
-  Cond clauses
+  cond' clauses
   where
     clauses = concatMap condClauses caseExpr
     caseExpr = straightenCaseExpr values caseAlternatives

--- a/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
@@ -84,7 +84,7 @@ exprToScheme (Abs _ann arg expr) =
   lambda1 (runIdent arg) (exprToScheme expr)
 
 exprToScheme (App _ann function arg) =
-  Application (exprToScheme function) [exprToScheme arg]
+  List [exprToScheme function, exprToScheme arg]
 
 exprToScheme _ = error "Not implemented"
 

--- a/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
@@ -12,7 +12,7 @@ import Language.PureScript.AST.Literals          (Literal(..))
 import Language.PureScript.Scheme.Util           (mapWithIndex, concatMapWithIndex)
 import Language.PureScript.Scheme.CodeGen.AST    (AST(..), everywhere)
 import Language.PureScript.Scheme.CodeGen.Scheme (t,
-                                                  define,
+                                                  define, lambda1,
                                                   eq, eqQ, and_, quote,
                                                   cons, car, cdr, cond',
                                                   vector, vectorRef)
@@ -65,7 +65,7 @@ exprToScheme (Literal _ann literal) =
 exprToScheme (Constructor _ann _typeName constructorName fields) =
   go fields
   where
-    go (x:xs) = Lambda (runIdent x) (go xs)
+    go (x:xs) = lambda1 (runIdent x) (go xs)
     go [] = cons (quote (Identifier (runProperName constructorName)))
                  (vector (fmap (\field -> Identifier (runIdent field)) fields))
 
@@ -81,7 +81,7 @@ exprToScheme (Case _ann values caseAlternatives) =
   caseToScheme values caseAlternatives
 
 exprToScheme (Abs _ann arg expr) =
-  Lambda (runIdent arg) (exprToScheme expr)
+  lambda1 (runIdent arg) (exprToScheme expr)
 
 exprToScheme (App _ann function arg) =
   Application (exprToScheme function) [exprToScheme arg]


### PR DESCRIPTION
Currently we're using AST for stuff that's clearly not syntax: Cond, Lambda, Define.

Going a step further, Scheme has no syntax other than primitive literals (symbols, numbers, strings) and lists. That's exactly what we call S-Expressions. (One could say S-Expressions also include dotted pairs `'(x . y)`, but since that's can be achieved with just `(cons 'x 'y)` we're not including them.)

What we lose: barely nothing. Using Cond to express `cond` expressions gives us no advantage, and the new design can handle conds with a final else expression in a clearer way. Using Lambda to express an anonymous function doesn't allow us to express functions with multiple parameters, which are not a thing in PureScript but they're definitely present in Scheme.

Overall it can give us more flexibility and the code change is rather small (+ 142 / - 167).

It might make the pretty printer slightly complex to make if we want to discriminate over AST, but it would just be an illusion and would bring us to add non-AST stuff to the AST.