### PR TITLE
Handle let expressions

### DIFF
--- a/test/resources/purescript/src/PureScheme/Test/Let/LambdasInFunction.purs
+++ b/test/resources/purescript/src/PureScheme/Test/Let/LambdasInFunction.purs
@@ -1,0 +1,10 @@
+module PureScheme.Test.Let.LambdasInFunction where
+
+import Prelude
+
+foo x y =
+  let
+    add a b = x + y
+    sub a b = x - y
+  in
+    add (sub x y) (add x y)

--- a/test/resources/purescript/src/PureScheme/Test/Let/TopLevelLambdas.purs
+++ b/test/resources/purescript/src/PureScheme/Test/Let/TopLevelLambdas.purs
@@ -1,0 +1,10 @@
+module PureScheme.Test.Let.TopLevelLambdas where
+
+import Prelude
+
+foo =
+  let
+    add x y = x + y
+    sub x y = x - y
+  in
+    add (sub 1 2) (add 3 4)

--- a/test/resources/purescript/src/PureScheme/Test/Let/TopLevelValues.purs
+++ b/test/resources/purescript/src/PureScheme/Test/Let/TopLevelValues.purs
@@ -1,0 +1,10 @@
+module PureScheme.Test.Let.TopLevelValues where
+
+import Prelude
+
+foo =
+  let
+    a = 1
+    b = 2
+  in
+    a + b

--- a/test/resources/purescript/src/PureScheme/Test/Let/ValuesInFunction.purs
+++ b/test/resources/purescript/src/PureScheme/Test/Let/ValuesInFunction.purs
@@ -1,0 +1,9 @@
+module PureScheme.Test.Let.ValuesInFunction where
+
+import Prelude
+
+foo x y =
+  let a = 1
+      b = 2
+  in
+    (x + a) - (y + b)

--- a/test/resources/scheme/PureScheme.Test.Let.LambdasInFunction.sls
+++ b/test/resources/scheme/PureScheme.Test.Let.LambdasInFunction.sls
@@ -1,0 +1,1 @@
+(define foo (lambda (dictRing) (lambda (x) (lambda (y) (let ((sub (lambda (a) (lambda (b) (((Data.Ring.sub dictRing) x) y)))) (add (lambda (a) (lambda (b) (((Data.Semiring.add ((hashtable-ref dictRing "Semiring0" (error #f "Key not found")) Prim.undefined)) x) y))))) ((add ((sub x) y)) ((add x) y)))))))

--- a/test/resources/scheme/PureScheme.Test.Let.TopLevelLambdas.sls
+++ b/test/resources/scheme/PureScheme.Test.Let.TopLevelLambdas.sls
@@ -1,0 +1,1 @@
+(define foo (let ((sub (lambda (x) (lambda (y) (- x y)))) (add (lambda (x) (lambda (y) (+ x y))))) ((add ((sub 1) 2)) ((add 3) 4))))

--- a/test/resources/scheme/PureScheme.Test.Let.TopLevelValues.sls
+++ b/test/resources/scheme/PureScheme.Test.Let.TopLevelValues.sls
@@ -1,0 +1,1 @@
+(define foo (let ((b 2) (a 1)) (+ a b)))

--- a/test/resources/scheme/PureScheme.Test.Let.ValuesInFunction.sls
+++ b/test/resources/scheme/PureScheme.Test.Let.ValuesInFunction.sls
@@ -1,0 +1,1 @@
+(define foo (lambda (x) (lambda (y) (let ((b 2) (a 1)) (- (+ x a) (+ y b))))))


### PR DESCRIPTION
Close #14 

I could not add the following test since the compiler complained about Accessor being not implemented

```
module PureScheme.Test.Let.LambdasInFunction where

import Prelude

foo x y =
  let
    add a b = x + y
    sub a b = x - y
  in
    add (sub x y) (add x y)
```

```
Compiling PureScheme.Test.Let.LambdasInFunction to test/resources/scheme/PureScheme.Test.Let.LambdasInFunction.sls                                                           
purescm-exe: Not implemented                                                          
CallStack (from HasCallStack):                                                        
  error, called at src/Language/PureScript/Scheme/CodeGen/Transpiler.hs:60:9 in purescm-0.0.1-7jQQA0FNYBqCYCmhGNiK2q:Language.PureScript.Scheme.CodeGen.Transpiler
```